### PR TITLE
Fix Python examples

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -17,7 +17,7 @@ from dpkt import ip
 
 count = 0
 
-def cb(i, payload):
+def cb(payload):
 	global count
 
 	print "python callback called !"

--- a/examples/nfq_asyncore.py
+++ b/examples/nfq_asyncore.py
@@ -16,8 +16,8 @@ import nfqueue
 sys.path.append('dpkt-1.6')
 from dpkt import ip
 
-def cb(i,payload):
-  print "python callback called !", i
+def cb(payload):
+  print "python callback called !"
 
   print "payload len ", payload.get_length()
   data = payload.get_data()

--- a/examples/nfq_dump_pcap.py
+++ b/examples/nfq_dump_pcap.py
@@ -20,7 +20,7 @@ from scapy.utils import PcapWriter, hexdump
 
 writer = None
 
-def cb(i,payload):
+def cb(payload):
     data = payload.get_data()
 
     # Add padding before packet

--- a/examples/rewrite.py
+++ b/examples/rewrite.py
@@ -15,7 +15,7 @@ import nfqueue
 sys.path.append('dpkt-1.6')
 from dpkt import ip, tcp, hexdump
 
-def cb(i,payload):
+def cb(payload):
 	print "payload len ", payload.get_length()
 	data = payload.get_data()
 	pkt = ip.IP(data)

--- a/examples/za.py
+++ b/examples/za.py
@@ -19,7 +19,7 @@ from dpkt import ip, tcp
 
 decisions = dict()
 
-def cb(i,payload):
+def cb(payload):
 	data = payload.get_data()
 	pkt = ip.IP(data)
 	print ""


### PR DESCRIPTION
I got a lot of errors that the callback takes 2 arguments but only one was passed, fe. `example.py`:

```
setting callback
open
trying to run
callback failure !
TypeError: cb() takes exactly 2 arguments (1 given)
^Cinterrupted
0 packets handled
unbind
close
```

Since the first parameter isn't used much anyway so the fix is pretty straight forward.
